### PR TITLE
Fix obtaining token and fetching billing metrics

### DIFF
--- a/pkg/selapi/billing.go
+++ b/pkg/selapi/billing.go
@@ -52,7 +52,7 @@ type BalanceResponse struct {
 
 func FetchBalance(token string) (*BalanceResponse, error) {
 	client := &http.Client{}
-	req, err := http.NewRequest("GET", "https://my.selectel.ru/api/v3/billing/balance", nil)
+	req, err := http.NewRequest("GET", "https://api.selectel.ru/v3/billing/balance", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/selapi/tokens.go
+++ b/pkg/selapi/tokens.go
@@ -33,7 +33,7 @@ func ObtainToken(token, projectId string) (*TokensResponse, error) {
 	client := &http.Client{}
 	req, err := http.NewRequest(
 		"POST",
-		"https://my.selectel.ru/api/vpc/resell/v2/tokens",
+		"https://api.selectel.ru/vpc/resell/v2/tokens",
 		bytes.NewBuffer(buf))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Current version prints this on bootup and crashes:
```
2023/09/14 14:28:37 response_format_error: can't parse TokensResponse
```

Looks like Selectel has updated their APIs so I adjusted the usage.